### PR TITLE
Fix Issue #30 AB#1432228

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "process-migrator",
-  "version": "0.9.4",
+  "version": "0.9.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -14,7 +14,7 @@
       "resolved": "https://registry.npmjs.org/@types/jqueryui/-/jqueryui-1.12.2.tgz",
       "integrity": "sha512-OZ3HZFxpyaoCgFO4qBliDS5QzeN+/X9Mr76VUD4L1TTOW0OYtnJl3bG4AfPI8Of7i0xgUA79Oo4KgteMnjllOQ==",
       "requires": {
-        "@types/jquery": "3.3.2"
+        "@types/jquery": "*"
       }
     },
     "@types/knockout": {
@@ -34,7 +34,7 @@
       "integrity": "sha512-U5icWpv7YnZYGsN4/cmh3WD2onMY0aJIiTE6+51TwJCttdHvtCYmkBNOobHlXwrJRL0nkH9jH4kD+1FAdMN4Tg==",
       "dev": true,
       "requires": {
-        "@types/node": "8.10.15"
+        "@types/node": "*"
       }
     },
     "@types/mousetrap": {
@@ -154,13 +154,13 @@
       "resolved": "https://registry.npmjs.org/vss-web-extension-sdk/-/vss-web-extension-sdk-5.131.0.tgz",
       "integrity": "sha512-iWJ3O4tzpRiPojYMmjqCh/IH3GptFTs1+Ahgbb/yXrueIggU85P0XpumtphIhUWsPan7mDlAYJHOMTHBgojc0Q==",
       "requires": {
-        "@types/jquery": "3.3.2",
-        "@types/jqueryui": "1.12.2",
-        "@types/knockout": "3.4.54",
-        "@types/mousetrap": "1.5.34",
+        "@types/jquery": ">=2.0.48",
+        "@types/jqueryui": ">=1.11.34",
+        "@types/knockout": "^3.4.49",
+        "@types/mousetrap": "~1.5.34",
         "@types/q": "0.0.32",
-        "@types/react": "15.6.15",
-        "@types/requirejs": "2.1.31"
+        "@types/react": "^15.6.12",
+        "@types/requirejs": ">=2.1.28"
       }
     }
   }


### PR DESCRIPTION
Fix the issue that an inherited group name is used by a custom group (and the inherited group gets a new name). 
Limitation of fix 
1) In theory page name is subject to same vulnerability but practically much less likely to happen 
2) If two inherited group name is swapped it will still error out. 